### PR TITLE
Fix bug in prune.rpart.R

### DIFF
--- a/R/prune.rpart.R
+++ b/R/prune.rpart.R
@@ -9,7 +9,7 @@ prune.rpart <- function(tree, cp, ...)
     temp <- pmax(tree$cptable[, 1L], cp)
     keep <- match(unique(temp), temp)
     newx$cptable <- tree$cptable[keep, , drop = FALSE]
-    newx$cptable[max(keep), 1L] <- cp
+    newx$cptable[length(keep), 1L] <- cp
     # Reset the variable importance
     newx$variable.importance <- importance(newx)
     newx


### PR DESCRIPTION
This fixes a bug in `prune.rpart.R` (https://github.com/bethatkinson/rpart/issues/4 and https://github.com/bethatkinson/rpart/issues/26) that can cause an index out of bounds error when the `cptable[1,]` has duplicate values.