### PR TITLE
Fix string format

### DIFF
--- a/src/rpart.c
+++ b/src/rpart.c
@@ -200,7 +200,7 @@ rpart(SEXP ncat2, SEXP method2, SEXP opt2,
     }
     i = (*rp_init) (n, rp.ydata, maxcat, &errmsg, parms, &rp.num_resp, 1, wt);
     if (i > 0)
-	error(errmsg);
+	error("%s", errmsg);
 
     nodesize = sizeof(Node) + (rp.num_resp - 20) * sizeof(double);
     tree = (pNode) ALLOC(1, nodesize);


### PR DESCRIPTION
With R-devel, as of r85619 (https://github.com/r-devel/r-svn/commit/f374bbf0), on my build machines I started getting failures when building rpart, because that commit added some string safety checks.

```
rpart.c: In function 'rpart':
rpart.c:203:9: error: format not a string literal and no format
arguments [-Werror=format-security]
  203 |         error(errmsg);
      |         ^~~~~
```

My understanding is that on most machines, this particular line of code raises a warning, but on mine it is an error. I'm not sure exactly why this is, but it seems like a good idea to address this anyway -- it is similar to a fix we recently had to do for a number of packages that CRAN sent emails about. For example:

- httpuv:
    - issue: https://github.com/rstudio/httpuv/issues/388
    - fix: https://github.com/rstudio/httpuv/pull/389/files
- later:
    - issue: https://github.com/r-lib/later/issues/181
    - fix https://github.com/r-lib/later/pull/182/files


The change in this pull request does the same thing as those other pull requests.