### PR TITLE
Fix partial matches in tests

### DIFF
--- a/tests/testall.R
+++ b/tests/testall.R
@@ -22,7 +22,7 @@ set.seed(10)
 #   tumor grade (Farrow) 1,2,3,4
 #   Gleason score (competing grading system)
 #   ploidy
-xgroup <- rep(1:10, length=nrow(stagec))
+xgroup <- rep(1:10, length.out=nrow(stagec))
 fit1 <- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
 		stagec, method="poisson",
               control=rpart.control(usesurrogate=0, cp=0, xval=xgroup))
@@ -45,7 +45,7 @@ names(mystate) <- c("population","income" , "illiteracy","life" ,
        "murder", "hs.grad", "frost",     "area",      "region")
 
 xvals <- 1:nrow(mystate)
-xvals[order(mystate$income)] <- rep(1:10, length=nrow(mystate))
+xvals[order(mystate$income)] <- rep(1:10, length.out=nrow(mystate))
 
 fit4 <- rpart(income ~ population + region + illiteracy +life + murder +
 			hs.grad + frost , mystate,
@@ -90,7 +90,7 @@ fit5 <- rpart(factor(pgstat) ~  age + eet + g2+grade+gleason +ploidy,
 fit5
 
 fit6 <- rpart(factor(pgstat) ~  age + eet + g2+grade+gleason +ploidy,
-		stagec, parm=list(prior=c(.5,.5)), xval=xgroup)
+		stagec, parms=list(prior=c(.5,.5)), xval=xgroup)
 summary(fit6)
 #
 # Fit a classification model to the car data.
@@ -98,7 +98,7 @@ summary(fit6)
 # make a lot of statistical sense, but it does test out some
 # areas of the code that nothing else does
 #
-xcar <- rep(1:8, length=nrow(cu.summary))
+xcar <- rep(1:8, length.out=nrow(cu.summary))
 carfit <- rpart(Reliability ~ Price + Country + Mileage + Type,
 		   method='class', data=cu.summary, xval=xcar)
 

--- a/tests/testall.Rout.save
+++ b/tests/testall.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2019-04-05 r76323) -- "Unsuffered Consequences"
-Copyright (C) 2019 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -40,7 +40,7 @@ Loading required package: survival
 > #   tumor grade (Farrow) 1,2,3,4
 > #   Gleason score (competing grading system)
 > #   ploidy
-> xgroup <- rep(1:10, length=nrow(stagec))
+> xgroup <- rep(1:10, length.out=nrow(stagec))
 > fit1 <- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
 + 		stagec, method="poisson",
 +               control=rpart.control(usesurrogate=0, cp=0, xval=xgroup))
@@ -412,7 +412,7 @@ Node number 51: 11 observations
 +        "murder", "hs.grad", "frost",     "area",      "region")
 > 
 > xvals <- 1:nrow(mystate)
-> xvals[order(mystate$income)] <- rep(1:10, length=nrow(mystate))
+> xvals[order(mystate$income)] <- rep(1:10, length.out=nrow(mystate))
 > 
 > fit4 <- rpart(income ~ population + region + illiteracy +life + murder +
 + 			hs.grad + frost , mystate,
@@ -636,7 +636,7 @@ node), split, n, loss, yval, (yprob)
       15) g2< 17.91 23  3 1 (0.1304 0.8696) *
 > 
 > fit6 <- rpart(factor(pgstat) ~  age + eet + g2+grade+gleason +ploidy,
-+ 		stagec, parm=list(prior=c(.5,.5)), xval=xgroup)
++ 		stagec, parms=list(prior=c(.5,.5)), xval=xgroup)
 > summary(fit6)
 Call:
 rpart(formula = factor(pgstat) ~ age + eet + g2 + grade + gleason + 
@@ -841,7 +841,7 @@ Node number 53: 8 observations
 > # make a lot of statistical sense, but it does test out some
 > # areas of the code that nothing else does
 > #
-> xcar <- rep(1:8, length=nrow(cu.summary))
+> xcar <- rep(1:8, length.out=nrow(cu.summary))
 > carfit <- rpart(Reliability ~ Price + Country + Mileage + Type,
 + 		   method='class', data=cu.summary, xval=xcar)
 > 
@@ -939,4 +939,4 @@ Node number 23: 8 observations
 > 
 > proc.time()
    user  system elapsed 
-  0.742   0.040   0.776 
+  0.846   0.057   0.896 

--- a/tests/treble.R
+++ b/tests/treble.R
@@ -42,9 +42,9 @@ pseudo <- double(nrow(stagec))
 pseudo[1] <- pi/4
 for (i in 2:nrow(stagec)) pseudo[i] <- 4*pseudo[i-1]*(1 - pseudo[i-1])
 
-wts <- rep(1:5, length=nrow(stagec))
+wts <- rep(1:5, length.out=nrow(stagec))
 temp <- rep(1:nrow(stagec), wts)             #row replicates
-xgrp <- rep(1:10, length=146)[order(pseudo)]
+xgrp <- rep(1:10, length.out=146)[order(pseudo)]
 xgrp2<- rep(xgrp, wts)
 #  Direct: replicate rows in the data set, and use unweighted
 fit2 <- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
@@ -54,7 +54,7 @@ fit2 <- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
 #  Weighted
 fit2b<- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
 	      control=rpart.control(minsplit=2, xval=xgrp, cp=.025),
-	      data=stagec, method='poisson', weight=wts)
+	      data=stagec, method='poisson', weights=wts)
 
 all.equal(fit2$frame[-2],  fit2b$frame[-2])  # the "n" component won't match
 all.equal(fit2$cptable,    fit2b$cptable)

--- a/tests/treble.Rout.save
+++ b/tests/treble.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2019-04-05 r76323) -- "Unsuffered Consequences"
-Copyright (C) 2019 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -62,9 +62,9 @@ Loading required package: survival
 > pseudo[1] <- pi/4
 > for (i in 2:nrow(stagec)) pseudo[i] <- 4*pseudo[i-1]*(1 - pseudo[i-1])
 > 
-> wts <- rep(1:5, length=nrow(stagec))
+> wts <- rep(1:5, length.out=nrow(stagec))
 > temp <- rep(1:nrow(stagec), wts)             #row replicates
-> xgrp <- rep(1:10, length=146)[order(pseudo)]
+> xgrp <- rep(1:10, length.out=146)[order(pseudo)]
 > xgrp2<- rep(xgrp, wts)
 > #  Direct: replicate rows in the data set, and use unweighted
 > fit2 <- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
@@ -74,7 +74,7 @@ Loading required package: survival
 > #  Weighted
 > fit2b<- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
 + 	      control=rpart.control(minsplit=2, xval=xgrp, cp=.025),
-+ 	      data=stagec, method='poisson', weight=wts)
++ 	      data=stagec, method='poisson', weights=wts)
 > 
 > all.equal(fit2$frame[-2],  fit2b$frame[-2])  # the "n" component won't match
 [1] TRUE
@@ -98,4 +98,4 @@ Loading required package: survival
 > 
 > proc.time()
    user  system elapsed 
-  0.706   0.053   0.753 
+  0.805   0.059   0.858 

--- a/tests/treble2.R
+++ b/tests/treble2.R
@@ -39,9 +39,9 @@ all.equal(xx2$frame$dev, c(82.5, 10, 2, .5, 10, .5, 2)*2)
 # Later -- cut it back to maxdepth=3 for the same reason (a tie).
 #
 nn <- nrow(mystate)
-wts <- rep(1:5, length=nn)
+wts <- rep(1:5, length.out=nn)
 temp <- rep(1:nn, wts)             #row replicates
-xgrp <- rep(1:10, length=nn)
+xgrp <- rep(1:10, length.out=nn)
 xgrp2<- rep(xgrp, wts)
 tempc <- rpart.control(minsplit=2, xval=xgrp2, maxsurrogate=0,
 		       maxcompete=3, maxdepth=3)

--- a/tests/treble2.Rout.save
+++ b/tests/treble2.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2019-04-05 r76323) -- "Unsuffered Consequences"
-Copyright (C) 2019 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -59,9 +59,9 @@ Type 'q()' to quit R.
 > # Later -- cut it back to maxdepth=3 for the same reason (a tie).
 > #
 > nn <- nrow(mystate)
-> wts <- rep(1:5, length=nn)
+> wts <- rep(1:5, length.out=nn)
 > temp <- rep(1:nn, wts)             #row replicates
-> xgrp <- rep(1:10, length=nn)
+> xgrp <- rep(1:10, length.out=nn)
 > xgrp2<- rep(xgrp, wts)
 > tempc <- rpart.control(minsplit=2, xval=xgrp2, maxsurrogate=0,
 + 		       maxcompete=3, maxdepth=3)
@@ -85,4 +85,4 @@ Type 'q()' to quit R.
 > 
 > proc.time()
    user  system elapsed 
-  0.102   0.031   0.128 
+  0.123   0.028   0.144 

--- a/tests/treble3.R
+++ b/tests/treble3.R
@@ -5,14 +5,14 @@
 library(rpart)
 set.seed(10)
 
-xgrp <- rep(1:10,length=nrow(cu.summary))
+xgrp <- rep(1:10,length.out=nrow(cu.summary))
 carfit <- rpart(Country ~ Reliability + Price + Mileage + Type,
 		 method='class', data=cu.summary, 
 		 control=rpart.control(xval=xgrp))
 
 carfit2 <- rpart(Country ~ Reliability + Price + Mileage + Type,
 		 method='class', data=cu.summary, 
-		 weight=rep(3,nrow(cu.summary)),
+		 weights=rep(3,nrow(cu.summary)),
 		 control=rpart.control(xval=xgrp))
 
 all.equal(carfit$frame$wt,    carfit2$frame$wt/3)

--- a/tests/treble3.Rout.save
+++ b/tests/treble3.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2019-04-05 r76323) -- "Unsuffered Consequences"
-Copyright (C) 2019 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -22,14 +22,14 @@ Type 'q()' to quit R.
 > library(rpart)
 > set.seed(10)
 > 
-> xgrp <- rep(1:10,length=nrow(cu.summary))
+> xgrp <- rep(1:10,length.out=nrow(cu.summary))
 > carfit <- rpart(Country ~ Reliability + Price + Mileage + Type,
 + 		 method='class', data=cu.summary, 
 + 		 control=rpart.control(xval=xgrp))
 > 
 > carfit2 <- rpart(Country ~ Reliability + Price + Mileage + Type,
 + 		 method='class', data=cu.summary, 
-+ 		 weight=rep(3,nrow(cu.summary)),
++ 		 weights=rep(3,nrow(cu.summary)),
 + 		 control=rpart.control(xval=xgrp))
 > 
 > all.equal(carfit$frame$wt,    carfit2$frame$wt/3)
@@ -164,4 +164,4 @@ Node number 13: 20 observations
 > 
 > proc.time()
    user  system elapsed 
-  0.114   0.017   0.125 
+  0.136   0.008   0.138 

--- a/tests/treble4.R
+++ b/tests/treble4.R
@@ -31,9 +31,9 @@ pseudo <- double(nn)
 pseudo[1] <- pi/6
 for (i in 2:nn) pseudo[i] <- 4*pseudo[i-1]*(1-pseudo[i-1])
 
-wts <-  rep(1:7, length=nn)
+wts <-  rep(1:7, length.out=nn)
 temp <- rep(1:nn, wts)             #row replicates
-xgrp <- rep(1:10, length=nn)[order(pseudo)]
+xgrp <- rep(1:10, length.out=nn)[order(pseudo)]
 xgrp2<- rep(xgrp, wts)
 
 # The cp value stops one last split where the two predictors are

--- a/tests/treble4.Rout.save
+++ b/tests/treble4.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2019-04-05 r76323) -- "Unsuffered Consequences"
-Copyright (C) 2019 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -49,9 +49,9 @@ Type 'q()' to quit R.
 > pseudo[1] <- pi/6
 > for (i in 2:nn) pseudo[i] <- 4*pseudo[i-1]*(1-pseudo[i-1])
 > 
-> wts <-  rep(1:7, length=nn)
+> wts <-  rep(1:7, length.out=nn)
 > temp <- rep(1:nn, wts)             #row replicates
-> xgrp <- rep(1:10, length=nn)[order(pseudo)]
+> xgrp <- rep(1:10, length.out=nn)[order(pseudo)]
 > xgrp2<- rep(xgrp, wts)
 > 
 > # The cp value stops one last split where the two predictors are
@@ -81,4 +81,4 @@ Type 'q()' to quit R.
 > 
 > proc.time()
    user  system elapsed 
-  0.130   0.020   0.144 
+  0.154   0.012   0.159 

--- a/tests/usersplits.R
+++ b/tests/usersplits.R
@@ -125,7 +125,7 @@ all.equal(fit1$where, fit2$where)
 all.equal(fit1$cptable, fit2$cptable)
 
 # Now try xpred on it
-xvtemp <- rep(1:5, length=50)
+xvtemp <- rep(1:5, length.out=50)
 xp1 <- xpred.rpart(fit1, xval=xvtemp)
 xp2 <- xpred.rpart(fit2, xval=xvtemp)
 aeq <- function(x,y) all.equal(as.vector(x), as.vector(y))

--- a/tests/usersplits.Rout.save
+++ b/tests/usersplits.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2019-04-05 r76323) -- "Unsuffered Consequences"
-Copyright (C) 2019 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -147,7 +147,7 @@ Type 'q()' to quit R.
 [1] TRUE
 > 
 > # Now try xpred on it
-> xvtemp <- rep(1:5, length=50)
+> xvtemp <- rep(1:5, length.out=50)
 > xp1 <- xpred.rpart(fit1, xval=xvtemp)
 > xp2 <- xpred.rpart(fit2, xval=xvtemp)
 > aeq <- function(x,y) all.equal(as.vector(x), as.vector(y))
@@ -169,4 +169,4 @@ Type 'q()' to quit R.
 > 
 > proc.time()
    user  system elapsed 
-  0.155   0.025   0.175 
+  0.173   0.035   0.201 

--- a/tests/xpred1.R
+++ b/tests/xpred1.R
@@ -6,7 +6,7 @@ library(rpart)
 set.seed(10)
 
 tdata <- data.frame(y=1:12, x1= 12:1, x2=c(1,1,5,5,4,4,9,9,7,7,3,3))
-xgrp <- rep(1:3, length=12)
+xgrp <- rep(1:3, length.out=12)
 
 fit1 <- rpart(y ~ x1 + x2, tdata, minsplit=6)
 xfit1 <- xpred.rpart(fit1, xval=xgrp, return.all=T)

--- a/tests/xpred1.Rout.save
+++ b/tests/xpred1.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2019-04-05 r76323) -- "Unsuffered Consequences"
-Copyright (C) 2019 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -23,7 +23,7 @@ Type 'q()' to quit R.
 > set.seed(10)
 > 
 > tdata <- data.frame(y=1:12, x1= 12:1, x2=c(1,1,5,5,4,4,9,9,7,7,3,3))
-> xgrp <- rep(1:3, length=12)
+> xgrp <- rep(1:3, length.out=12)
 > 
 > fit1 <- rpart(y ~ x1 + x2, tdata, minsplit=6)
 > xfit1 <- xpred.rpart(fit1, xval=xgrp, return.all=T)
@@ -51,4 +51,4 @@ Type 'q()' to quit R.
 > 
 > proc.time()
    user  system elapsed 
-  0.141   0.015   0.151 
+  0.164   0.015   0.174 

--- a/tests/xpred2.R
+++ b/tests/xpred2.R
@@ -9,7 +9,7 @@ set.seed(10)
 fit1 <- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
                 stagec,  method='poisson')
 
-xgrp <- rep(1:3, length=nrow(stagec))  # explicitly set the xval groups
+xgrp <- rep(1:3, length.out=nrow(stagec))  # explicitly set the xval groups
 
 xfit1 <- xpred.rpart(fit1, xval=xgrp, return.all=T)
 xfit2 <- array(0, dim=dim(xfit1))

--- a/tests/xpred2.Rout.save
+++ b/tests/xpred2.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2019-04-05 r76323) -- "Unsuffered Consequences"
-Copyright (C) 2019 The R Foundation for Statistical Computing
-Platform: x86_64-pc-linux-gnu (64-bit)
+R version 4.4.0 (2024-04-24) -- "Puppy Cup"
+Copyright (C) 2024 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -27,7 +27,7 @@ Loading required package: survival
 > fit1 <- rpart(Surv(pgtime, pgstat) ~ age + eet + g2+grade+gleason +ploidy,
 +                 stagec,  method='poisson')
 > 
-> xgrp <- rep(1:3, length=nrow(stagec))  # explicitly set the xval groups
+> xgrp <- rep(1:3, length.out=nrow(stagec))  # explicitly set the xval groups
 > 
 > xfit1 <- xpred.rpart(fit1, xval=xgrp, return.all=T)
 > xfit2 <- array(0, dim=dim(xfit1))
@@ -54,4 +54,4 @@ Loading required package: survival
 > 
 > proc.time()
    user  system elapsed 
-  0.752   0.035   0.782 
+  0.845   0.065   0.903 


### PR DESCRIPTION
This is part of an effort to make R-devel and Recommended-priority packages behave better under strict sessions that don't allow partial matching by default.