### PR TITLE
fix "undeclared package 'tree' in Rd xrefs"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Recursive partitioning for classification,
   functionality of the 1984 book by Breiman, Friedman, Olshen and Stone.
 Title: Recursive Partitioning and Regression Trees
 Depends: R (>= 2.15.0), graphics, stats, grDevices
-Suggests: survival
+Suggests: survival, tree
 License: GPL-2 | GPL-3
 LazyData: yes
 ByteCompile: yes
@@ -24,6 +24,5 @@ Author: Terry Therneau [aut],
   Brian Ripley [trl] (producer of the initial R port, maintainer
     1999-2017)
 Maintainer: Beth Atkinson <atkinson@mayo.edu>
-Repository: CRAN
 URL: https://github.com/bethatkinson/rpart, https://cran.r-project.org/package=rpart
 BugReports: https://github.com/bethatkinson/rpart/issues

--- a/man/rpart.control.Rd
+++ b/man/rpart.control.Rd
@@ -52,8 +52,8 @@ rpart.control(minsplit = 20, minbucket = round(minsplit/3), cp = 0.01,
     if all surrogates are missing the observation is not split.  For value
     \code{2} ,if all surrogates are missing, then send the observation in
     the majority direction.  A value of \code{0} corresponds to the action
-    of \code{tree}, and \code{2} to the recommendations of Breiman
-    \emph{et.al} (1984).
+    of \code{\link[tree]{tree}}, and \code{2} to the recommendations of Breiman
+    \emph{et al.} (1984).
   }
   \item{xval}{
     number of cross-validations.


### PR DESCRIPTION
`?predict.rpart` links to `?tree::tree` here

https://github.com/bethatkinson/rpart/blob/123a2cd343b548a12850a2a68083536914e9e6e5/man/predict.rpart.Rd#L31

but package 'tree' was not declared in the DESCRIPTION file, leading to a check note:

    * checking Rd cross-references ... INFO
    Undeclared package 'tree' in Rd xrefs

This PR fixes it.

(I also removed the 'Repository' field as that should only be added by the repository,
and linked 'tree' on another help page.)